### PR TITLE
add try-runtime-ci

### DIFF
--- a/.github/templates/setup-worker/action.yml
+++ b/.github/templates/setup-worker/action.yml
@@ -1,0 +1,19 @@
+name: setup-worker
+description: |
+  This action sets up a worker for use in other actions. It installs the
+  necessary dependencies for building the project.
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Setup Ubuntu dependencies
+      shell: bash
+      run: sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake protobuf-compiler
+
+    - name: Install Rust nightly
+      shell: bash
+      run: |
+        rustup toolchain install nightly-2023-01-01 --profile minimal --component rustfmt
+        rustup default nightly-2023-01-01
+        rustup target add wasm32-unknown-unknown

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -1,0 +1,45 @@
+# Test storage migration using try-runtime on PRs with label "migration"
+name: Test storage migration
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  push:
+    branches: [ main ]
+
+jobs:
+  try_runtime:
+    if: contains(github.event.pull_request.labels.*.name, 'migration')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Setup worker
+        uses: "./.github/templates/setup-worker"
+
+      - name: Cache Build artefacts
+        uses: actions/cache/restore@v3
+        id: cargo-cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ env.POLKA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-${{ env.POLKA_VERSION }}
+
+      - name: Install try-runtime
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+
+      # a live RPC node is required for the below work
+      - run: |
+          echo "Found label runtime_migration. Running tests"
+          echo "---------- Running try-runtime for extended-parachain-template ----------"
+          cargo build -p parachain-template-node --locked --release --no-default-features --features parachain-template-node/mainnet-runtime,try-runtime && \
+          try-runtime --runtime ./target/release/wbuild/mainnet-runtime/target/wasm32-unknown-unknown/release/mainnet_runtime.wasm \
+              on-runtime-upgrade live --uri wss://mainnet-try-runtime-node.parity.io:443
+        env:
+          RUST_LOG: remote-ext=debug,runtime=debug


### PR DESCRIPTION
closes #76 

This PR makes it so [try-runtime](https://paritytech.github.io/try-runtime-cli/try_runtime/) will run when a `migration` label is added to a PR.