### PR TITLE
fix: pay fees with native parachain token

### DIFF
--- a/runtime/devnet/src/xcm_config.rs
+++ b/runtime/devnet/src/xcm_config.rs
@@ -220,8 +220,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type Trader =
-		UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = PolkadotXcm;
 	type AssetLocker = ();

--- a/runtime/mainnet/src/xcm_config.rs
+++ b/runtime/mainnet/src/xcm_config.rs
@@ -220,8 +220,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type Trader =
-		UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = PolkadotXcm;
 	type AssetLocker = ();


### PR DESCRIPTION
With this change the fees for receiving xcm transactions will be paid with the native parachain token in stead of the relay chain token. Prior to this change it would error into `TooExpensive` ([ref](https://substrate.stackexchange.com/questions/2208/xcm-buyexecution-fail-tooexpensive-when-transferring-native-token-from-your-par)). 