### PR TITLE
Example Parachain Integration tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -29,6 +29,8 @@ Please refer to the [project's `README.md`](https://github.com/paritytech/parach
 
 In `integration-tests/force_hrmp_open_channels.yml` you can find a test to open a HRMP channel between this parachain and an asset-hub local network.
 
+In `integration-tests/transact.yml` you can find a test to make a transfer from this parachain sovereign account to asset-hub local network sovereign account via a XCM Transact in the Relay Chain.
+
 Run zombienet and wait until both parachains are propertly onboarded (producing blocks):
 ```
 $ zombienet-macos spawn zombienet-config/integration-tests-config.toml -p native
@@ -37,4 +39,5 @@ $ zombienet-macos spawn zombienet-config/integration-tests-config.toml -p native
 Run the tests:
 ```
 $ parachains-integration-tests -m test -t integration-tests/force_hrmp_open_channels.yml
+$ parachains-integration-tests -m test -t integration-tests/transact.yml
 ```

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,30 @@
+[`parachains-integration-tests`](https://github.com/paritytech/parachains-integration-tests) is a tool designed to test interactions between Substrate based blockchains.
+
+Is used here to develop tests rapidly describing them in a YAML file.
+
+# Setup
+
+Install `parachains-integration-tests` into your system:
+```
+$ yarn global add ts-node
+
+$ yarn global add @parity/parachains-integration-tests
+```
+
+Review the [Run a local network](https://github.com/paritytech/extended-parachain-template#%EF%B8%8F-run-a-local-network) to set up Zombienet in your system.
+
+Create a `bin` directory into the root of this repository and place the following binaries inside of it:
+- `polkadot` (which you can download from [the releases](https://github.com/paritytech/polkadot/releases))
+- `polkadot-parachain` (which you will build from [cumulus](https://github.com/paritytech/cumulus))
+
+Use the following command in the root of this repository to build the node:
+
+```sh
+cargo build --release
+```
+
+# Usage
+
+Please refer to the [project's `README.md`](https://github.com/paritytech/parachains-integration-tests#how-to-use) for an extensive description of how to write YAML test files and how to execute tests.
+
+

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -14,7 +14,8 @@ $ yarn global add @parity/parachains-integration-tests
 Review the [Run a local network](https://github.com/paritytech/extended-parachain-template#%EF%B8%8F-run-a-local-network) to set up Zombienet in your system.
 
 Create a `bin` directory into the root of this repository and place the following binaries inside of it:
-- `polkadot` (which you can download from [the releases](https://github.com/paritytech/polkadot/releases))
+- `polkadot` (which you can download from [the releases](https://github.com/paritytech/polkadot/releases)).
+Note: Downloading polkadot will automatically download also the binaries of `polkadot-prepare-worker`, `polkadot-execute-worker`. Since Polkadot v1.0 all 3 binaries are needed for the node to run as a validator
 - `polkadot-parachain` (which you will build from [cumulus](https://github.com/paritytech/cumulus))
 
 Use the following command in the root of this repository to build the node:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -15,6 +15,7 @@ Review the [Run a local network](https://github.com/paritytech/extended-parachai
 
 Create a `bin` directory into the root of this repository and place the following binaries inside of it:
 - `polkadot` (which you can download from [the releases](https://github.com/paritytech/polkadot/releases)).
+
 Note: Downloading polkadot will automatically download also the binaries of `polkadot-prepare-worker`, `polkadot-execute-worker`. Since Polkadot v1.0 all 3 binaries are needed for the node to run as a validator
 - `polkadot-parachain` (which you will build from [cumulus](https://github.com/paritytech/cumulus))
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -27,4 +27,14 @@ cargo build --release
 
 Please refer to the [project's `README.md`](https://github.com/paritytech/parachains-integration-tests#how-to-use) for an extensive description of how to write YAML test files and how to execute tests.
 
+In `integration-tests/force_hrmp_open_channels.yml` you can find a test to open a HRMP channel between this parachain and an asset-hub local network.
 
+Run zombienet and wait until both parachains are propertly onboarded (producing blocks):
+```
+$ zombienet-macos spawn zombienet-config/integration-tests-config.toml -p native
+```
+
+Run the tests:
+```
+$ parachains-integration-tests -m test -t integration-tests/force_hrmp_open_channels.yml
+```

--- a/integration-tests/force_hrmp_open_channels.yml
+++ b/integration-tests/force_hrmp_open_channels.yml
@@ -1,0 +1,122 @@
+---
+settings:
+  chains:
+    relay_chain: &relay_chain
+      wsPort: 9900
+    assets_parachain:
+      wsPort: 9910
+      paraId: &ap_id 1000
+    local_parachain:
+      wsPort: 9920
+      paraId: &lp_id 2000
+  variables:
+    common:
+      amount: &amount 2000000000000
+      hrmp_channels:
+        proposed_max_capacity: &max_capacity 8
+        proposed_max_message_size: &max_message_size 8192
+        channel: &channel {
+          maxCapacity: *max_capacity,
+          maxTotalSize: *max_message_size,
+          maxMessageSize: *max_message_size,
+          msgCount: 0,
+          totalSize: 0,
+          mqcHead: null,
+          senderDeposit: 0,
+          recipientDeposit: 0
+        }
+    chains:
+      relay_chain:
+        signer: &rc_signer //Alice
+      assets_parachain_account:
+        sovereign_account: &ap_sovereign F7fq1jSNVTPfJmaHaXCMtatT1EZefCUsa7rRiQVNR5efcah
+      local_parachain:
+        sovereign_account: &lp_sovereign F7fq1jMZkfuCuoMTyiEVAP2DMpMt18WopgBqTJznLihLNbZ
+
+tests:
+  - name: HRMP
+    beforeEach:
+      - name: DEPENDENCY | Local Parachain Sovereign account in the Relay Chain needs to be funded
+        actions:
+          - extrinsics:
+              - chain: *relay_chain
+                signer: *rc_signer
+                pallet: balances
+                call: transferAllowDeath
+                args: [
+                  *lp_sovereign, # destination
+                  *amount, # value
+                ]
+                events:
+                  - name: balances.Transfer
+
+      - name: DEPENDENCY | Assets Parachain Sovereign account in the Relay Chain needs to be funded
+        actions:
+          - extrinsics:
+              - chain: *relay_chain
+                signer: *rc_signer
+                pallet: balances
+                call: transferAllowDeath
+                args: [
+                  *ap_sovereign, # destination
+                  *amount, # value
+                ]
+                events:
+                  - name: balances.Transfer
+    describes:
+      - name: hrmp.forceOpenHrmpChannel (Local Parachain → Assets Parachain)
+        its:
+          - name: Open Local Parachain to Assets Parachain
+            actions:
+              - extrinsics:
+                  - chain: *relay_chain
+                    signer: *rc_signer
+                    sudo: true
+                    pallet: hrmp
+                    call: forceOpenHrmpChannel
+                    args: [
+                      *lp_id,
+                      *ap_id,
+                      *max_capacity,
+                      *max_message_size
+                    ]
+                    events:
+                      - name: sudo.Sudid
+                        result: { sudoResult: Ok }
+                      - name: hrmp.HrmpChannelForceOpened
+
+      - name: hrmp.forceOpenHrmpChannel (Assets Parachain → Local Parachain)
+        its:
+          - name: Open Assets Parachain to Local Parachain
+            actions:
+              - extrinsics:
+                  - chain: *relay_chain
+                    signer: *rc_signer
+                    sudo: true
+                    pallet: hrmp
+                    call: forceOpenHrmpChannel
+                    args: [
+                      *ap_id,
+                      *lp_id,
+                      *max_capacity,
+                      *max_message_size
+                    ]
+                    events:
+                      - name: sudo.Sudid
+                        result: { sudoResult: Ok }
+                      - name: hrmp.HrmpChannelForceOpened
+
+      - name: hrmp.forceProcessHrmpOpen (make sure all the channels are open)
+        its:
+          - name: Make sure all the pending channels are open
+            actions:
+              - extrinsics:
+                  - chain: *relay_chain
+                    signer: *rc_signer
+                    sudo: true
+                    pallet: hrmp
+                    call: forceProcessHrmpOpen
+                    args: [ 2 ]
+                    events:
+                      - name: sudo.Sudid
+                        result: { sudoResult: Ok }

--- a/integration-tests/force_hrmp_open_channels.yml
+++ b/integration-tests/force_hrmp_open_channels.yml
@@ -11,10 +11,10 @@ settings:
       paraId: &lp_id 2000
   variables:
     common:
-      amount: &amount 2000000000000
+      amount: &amount 20000000000000
       hrmp_channels:
         proposed_max_capacity: &max_capacity 8
-        proposed_max_message_size: &max_message_size 8192
+        proposed_max_message_size: &max_message_size 1048576
         channel: &channel {
           maxCapacity: *max_capacity,
           maxTotalSize: *max_message_size,
@@ -35,7 +35,7 @@ settings:
 
 tests:
   - name: HRMP
-    beforeEach:
+    before:
       - name: DEPENDENCY | Local Parachain Sovereign account in the Relay Chain needs to be funded
         actions:
           - extrinsics:

--- a/integration-tests/transact.yml
+++ b/integration-tests/transact.yml
@@ -1,0 +1,92 @@
+---
+settings:
+  chains:
+    relay_chain: &relay_chain
+      wsPort: 9900
+    assets_parachain: &assets_parachain
+      wsPort: 9910
+      paraId: &ap_id 1000
+    local_parachain: &local_parachain
+      wsPort: 9920
+      paraId: &lp_id 2000
+  variables:
+    common:
+      amount: &amount 120000000000
+      amount_to_send: &amount_to_send 500000000000
+      require_weight_at_most: &weight_at_most {refTime: 1000000000, proofSize: 200000}
+    chains:
+      assets_parachain:
+        assets_sovereign_account: &ap_sovereign 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ
+      local_parachain:
+        signer: &lp_signer //Alice
+        relay_chain_dest_routed: &relay_dest_routed { v3: { parents: 1, interior: Here }}
+        local_sovereign_account: &lp_sovereign 5Ec4AhPUwPeyTFyuhGuBbD224mY85LKLMSqSSo33JYWCazU4
+  decodedCalls:
+    transfer_allow_death:
+        chain: *relay_chain
+        pallet: balances
+        call: transferAllowDeath
+        args: [ 
+          { Id: *ap_sovereign }, # destination
+          *amount_to_send, # value
+        ]
+
+tests:
+  - name: Transfer from Local Parachain Sovereign Account to Assets Parachain Sovereign account
+    its:
+      - name: Transact ->  Local Parachain sends XCM instructions to make a transact on Relay Chain.
+        actions:
+          - extrinsics:
+              - chain: *local_parachain
+                signer: *lp_signer
+                sudo: true
+                pallet: polkadotXcm
+                call: send
+                args: [
+                  *relay_dest_routed, # destination
+                  { # message
+                    v3: [
+                      {
+                        WithdrawAsset: [
+                          { 
+                            id: {
+                              concrete: {
+                                parents: 0,
+                                interior: Here
+                              }
+                            }, 
+                            fun: { fungible: *amount }
+                          }
+                        ]
+                      },
+                      {
+                        BuyExecution: {
+                          fees: { 
+                            id: {
+                              concrete: {
+                                parents: 0,
+                                interior: Here
+                              }
+                            },
+                            fun: { fungible: *amount }
+                          },
+                          weightLimit: Unlimited
+                        }
+                      },
+                      {
+                        Transact: {
+                          originKind: SovereignAccount,
+                          requireWeightAtMost: *weight_at_most,
+                          call: $transfer_allow_death
+                        }
+                      },
+                    ]
+                  }
+                ]
+                events:
+                  - name: sudo.Sudid
+                    result: { sudoResult: Ok }
+                  - name: polkadotXcm.Sent
+                  - name: balances.Transfer
+                    chain: *relay_chain
+                    result: { from: *lp_sovereign, to: *ap_sovereign }

--- a/zombienet-config/integration-tests-config.toml
+++ b/zombienet-config/integration-tests-config.toml
@@ -1,0 +1,69 @@
+[relaychain]
+chain = "rococo-local"
+default_command = "./bin/polkadot"
+
+  [[relaychain.nodes]]
+  name = "alice"
+  validator = true
+  ws_port = 9900
+  extra_args = [ "-lparachain=debug" ]
+
+  [[relaychain.nodes]]
+  name = "bob"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "charlie"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "dave"
+  validator = true
+
+[[parachains]]
+id = 1000
+add_to_genesis = true
+cumulus_based = true
+chain = "statemine-local"
+
+  [[parachains.collators]]
+  name = "statemine-collator01"
+  command = "./bin/polkadot-parachain"
+  ws_port = 9910
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
+  [[parachains.collators]]
+  name = "statemine-collator02"
+  command = "./bin/polkadot-parachain"
+  ws_port = 9911
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
+[[parachains]]
+id = 2000
+addToGenesis = true
+cumulus_based = true
+
+  [[parachains.collators]]
+  name = "parachain-collator01"
+  command = "./target/release/parachain-template-node"
+  ws_port = 9920
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
+  [[parachains.collators]]
+  name = "parachain-collator02"
+  command = "./target/release/parachain-template-node"
+  ws_port = 9921
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
+
+[[hrmp_channels]]
+sender = 1000
+recipient = 2000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 2000
+recipient = 1000
+max_capacity = 8
+max_message_size = 512

--- a/zombienet-config/integration-tests-config.toml
+++ b/zombienet-config/integration-tests-config.toml
@@ -30,16 +30,16 @@ default_command = "./bin/polkadot"
 id = 1000
 add_to_genesis = true
 cumulus_based = true
-chain = "statemine-local"
+chain = "asset-hub-kusama-local"
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "asset-hub-kusama-local-collator01"
   command = "./bin/polkadot-parachain"
   ws_port = 9910
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
   [[parachains.collators]]
-  name = "statemine-collator02"
+  name = "asset-hub-kusama-local-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]

--- a/zombienet-config/integration-tests-config.toml
+++ b/zombienet-config/integration-tests-config.toml
@@ -1,3 +1,6 @@
+[settings]
+timeout = 1000
+
 [relaychain]
 chain = "rococo-local"
 default_command = "./bin/polkadot"
@@ -11,14 +14,17 @@ default_command = "./bin/polkadot"
   [[relaychain.nodes]]
   name = "bob"
   validator = true
+  extra_args = [ "-lparachain=debug" ]
 
   [[relaychain.nodes]]
   name = "charlie"
   validator = true
+  extra_args = [ "-lparachain=debug" ]
 
   [[relaychain.nodes]]
   name = "dave"
   validator = true
+  extra_args = [ "-lparachain=debug" ]
 
 [[parachains]]
 id = 1000
@@ -55,15 +61,19 @@ cumulus_based = true
   ws_port = 9921
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"
 
-[[hrmp_channels]]
-sender = 1000
-recipient = 2000
-max_capacity = 8
-max_message_size = 512
+# [[hrmp_channels]]
+# sender = 1000
+# recipient = 2000
+# max_capacity = 8
+# max_message_size = 512
 
-[[hrmp_channels]]
-sender = 2000
-recipient = 1000
-max_capacity = 8
-max_message_size = 512
+# [[hrmp_channels]]
+# sender = 2000
+# recipient = 1000
+# max_capacity = 8
+# max_message_size = 512


### PR DESCRIPTION
Solved the issue [QA] Example Parachain Integration tests https://github.com/paritytech/extended-parachain-template/issues/77.

Added the instructions of how to run the integration tests, set up the zombienet file and two tests files: 

- `force_hrmp_open_channels`: creates an HRMP channel with asset-hub and checks that everything is created propertly.

I decided to create this test, because there currently there is an issue: (draft) Zombienet test with preopen hrmp with zombienet investigation https://github.com/paritytech/polkadot-sdk/pull/1616 that is unable to create the hrmp channels directly with zombienet, so this test can be useful.

- `transact`: Test to make a transfer from this parachain sovereign account to asset-hub local network sovereign account via a XCM Transact in the Relay Chain.


Bonus point:
We can create one reserve transfer similar [to the one in Trappist ](https://github.com/paritytech/trappist/tree/main/integration-tests) once we have this: Minimal AssetHub integration https://github.com/paritytech/extended-parachain-template/issues/79