### PR TITLE
Fix zombienet polkadot build

### DIFF
--- a/zombienet.sh
+++ b/zombienet.sh
@@ -31,7 +31,7 @@ build_polkadot(){
       git checkout release-polkadot-$POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime
-      cp ${POLKADOT_FILES[@]/#/target/release/} $CWD/bin
+      cp "${POLKADOT_FILES[@]/#/target/release/}" "$CWD/bin"
     popd
   popd
 }

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -22,7 +22,7 @@ build_polkadot(){
   pushd /tmp
     git clone https://github.com/paritytech/polkadot-sdk.git
     pushd polkadot-sdk
-      git checkout $POLKADOT_V
+      git checkout release-polkadot-$POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime
       cp target/release/polkadot $CWD/bin

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -3,6 +3,12 @@
 ZOMBIENET_V=v1.3.68
 POLKADOT_V=v1.1.0
 
+POLKADOT_FILES=(
+  "polkadot"
+  "polkadot-execute-worker"
+  "polkadot-prepare-worker"
+)
+
 case "$(uname -s)" in
     Linux*)     MACHINE=Linux;;
     Darwin*)    MACHINE=Mac;;
@@ -25,7 +31,7 @@ build_polkadot(){
       git checkout release-polkadot-$POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime
-      cp target/release/polkadot $CWD/bin
+      cp ${POLKADOT_FILES[@]/#/target/release/} $CWD/bin
     popd
   popd
 }
@@ -36,9 +42,9 @@ zombienet_init() {
     curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
     chmod +x $ZOMBIENET_BIN
   fi
-  if [ ! -f bin/polkadot ]; then
-    build_polkadot
-  fi
+  for file in "${POLKADOT_FILES[@]}"; do
+      [[ -f "bin/$file" ]] || { build_polkadot; break; }
+  done
 }
 
 zombienet_spawn() {

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -21,7 +21,7 @@ build_polkadot(){
   mkdir -p bin
   pushd /tmp
     git clone https://github.com/paritytech/polkadot-sdk.git
-    pushd polkadot
+    pushd polkadot-sdk
       git checkout $POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -3,12 +3,6 @@
 ZOMBIENET_V=v1.3.68
 POLKADOT_V=v1.1.0
 
-POLKADOT_FILES=(
-  "polkadot"
-  "polkadot-execute-worker"
-  "polkadot-prepare-worker"
-)
-
 case "$(uname -s)" in
     Linux*)     MACHINE=Linux;;
     Darwin*)    MACHINE=Mac;;
@@ -31,7 +25,9 @@ build_polkadot(){
       git checkout release-polkadot-$POLKADOT_V
       echo "building polkadot executable..."
       cargo build --release --features fast-runtime
-      cp "${POLKADOT_FILES[@]/#/target/release/}" "$CWD/bin"
+      cp target/release/polkadot "$CWD/bin"
+      cp target/release/polkadot-execute-worker "$CWD/bin"
+      cp target/release/polkadot-prepare-worker "$CWD/bin"
     popd
   popd
 }
@@ -42,9 +38,9 @@ zombienet_init() {
     curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
     chmod +x $ZOMBIENET_BIN
   fi
-  for file in "${POLKADOT_FILES[@]}"; do
-      [[ -f "bin/$file" ]] || { build_polkadot; break; }
-  done
+  if [ ! -f bin/polkadot ] || [ ! -f bin/polkadot-execute-worker ] || [ ! -f bin/polkadot-prepare-worker ]; then
+    build_polkadot
+  fi
 }
 
 zombienet_spawn() {


### PR DESCRIPTION
* Repository renamed, should `pushd` a renamed dir too,
* Branch naming pattern now has a `polkadot-` prefix, example: https://github.com/paritytech/polkadot-sdk/tree/polkadot-v1.1.0,
* Three executables are required to launch the relay chain, ensure the existence of all 3 of them.
