### PR TITLE
ci: Upgrade actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/build-deterministic-runtime.yml
+++ b/.github/workflows/build-deterministic-runtime.yml
@@ -45,7 +45,7 @@ jobs:
         run: cp `dirname ${{ steps.srtool_build.outputs.wasm }}`/*.wasm ./
       - name: Archive Runtime
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
           path: |


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024, updating them.

cc https://github.com/paritytech/ci_cd/issues/1078